### PR TITLE
Listar contato bug fix

### DIFF
--- a/CadastroApi/CadastroApi/Application/AtualizarContato/AtualizarContatoCommandHandler.cs
+++ b/CadastroApi/CadastroApi/Application/AtualizarContato/AtualizarContatoCommandHandler.cs
@@ -17,14 +17,15 @@ namespace CadastroApi.Application
         {
             command.Validate();
 
-            var contato = new Contato
-            {
-                Id = command.ID,
-                Nome = command.Nome,
-                Telefone = command.Telefone,
-                DDD = command.DDD,
-                Email = command.Email,
-            };
+            var contato = await _contatoRepository.GetByIdAsync(command.ID);
+
+            if (contato is null)
+                throw new KeyNotFoundException();
+
+            contato.Nome = command.Nome;
+            contato.Telefone = command.Telefone;
+            contato.DDD = command.DDD;
+            contato.Email = command.Email;
 
             await _contatoRepository.UpdateContatoAsync(contato);
 

--- a/CadastroApi/CadastroApi/Application/Extensions/ValidationExceptionExtension.cs
+++ b/CadastroApi/CadastroApi/Application/Extensions/ValidationExceptionExtension.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+
+namespace CadastroApi.Application.Extensions
+{
+    public static class ValidationExceptionExtension
+    {
+        public static string[] ToResultMessage(this ValidationException exception) 
+        {
+            if (exception.Errors == null || exception.Errors.Count() == 0)
+                return Array.Empty<string>();
+
+
+            return exception.Errors.Select(x => x.ErrorMessage).ToArray();
+        }
+    }
+}

--- a/CadastroApi/CadastroApi/Repository/ContatoRepository.cs
+++ b/CadastroApi/CadastroApi/Repository/ContatoRepository.cs
@@ -10,22 +10,6 @@ public class ContatoRepository : Repository<Contato>, IContatoRepository
     {
     }
 
-    public async Task<IEnumerable<Contato>> GetAllAsync(int? pageIndex, int? pageSize)
-    {
-        var query = _context.Contatos
-            .AsNoTracking()
-            .OrderBy(c => c.Nome)
-            .AsQueryable();
-
-        if (pageIndex is null || pageSize is null)
-            return await query.ToListAsync();
-
-        return await query
-            .Skip((pageIndex.Value - 1) * pageSize.Value)
-            .Take(pageSize.Value)
-            .ToListAsync();
-    }
-
     public async Task<IEnumerable<Contato>> GetByDDDAsync(string ddd, int? pageIndex, int? pageSize)
     {
         var query = _context.Contatos

--- a/CadastroApi/CadastroApi/Repository/ContatoRepository.cs
+++ b/CadastroApi/CadastroApi/Repository/ContatoRepository.cs
@@ -35,11 +35,6 @@ public class ContatoRepository : Repository<Contato>, IContatoRepository
 
     public async Task UpdateContatoAsync(Contato contato)
     {
-        var contatoToUpdate = await _context.Contatos.AsNoTracking().Where(c => c.Id == contato.Id).FirstOrDefaultAsync();
-
-        if (contatoToUpdate == null)
-            throw new ArgumentException($"Id: {contato.Id} não encontrado na base de dados.");
-
         _context.Contatos.Update(contato);
         await _context.SaveChangesAsync();
     }

--- a/CadastroApi/CadastroApi/Repository/IContatoRepository.cs
+++ b/CadastroApi/CadastroApi/Repository/IContatoRepository.cs
@@ -4,7 +4,6 @@ namespace CadastroApi.Repository;
 
 public interface IContatoRepository : IRepository<Contato>
 {
-    Task<IEnumerable<Contato>> GetAllAsync(int? pageIndex, int? pageSize);
     Task<IEnumerable<Contato>> GetByDDDAsync(string ddd, int? pageIndex, int? pageSize);
     Task AddContatoAsync(Contato contato);
     Task UpdateContatoAsync(Contato contato);   

--- a/CadastroApi/CadastroApi/Repository/IRepository.cs
+++ b/CadastroApi/CadastroApi/Repository/IRepository.cs
@@ -2,7 +2,7 @@
 
 public interface IRepository<T>
 {
-    Task<IEnumerable<T>> GetAllAsync();
+    Task<IEnumerable<T>> GetAllAsync(int? pageIndex, int? pageSize);
     Task<T> GetByIdAsync(Guid id);
     Task CreateAsync(T entity);
     void Update(T entity);

--- a/CadastroApi/CadastroApi/Repository/Repository.cs
+++ b/CadastroApi/CadastroApi/Repository/Repository.cs
@@ -12,9 +12,19 @@ public class Repository<T> : IRepository<T> where T : class
         _context = context;
     }
 
-    public async Task<IEnumerable<T>> GetAllAsync()
+    public async Task<IEnumerable<T>> GetAllAsync(int? pageIndex, int? pageSize)
     {
-        return await _context.Set<T>().AsNoTracking().ToListAsync();
+        var query = _context.Set<T>()
+            .AsNoTracking()            
+            .AsQueryable();
+
+        if (pageIndex is null || pageSize is null)
+            return await query.ToListAsync();
+
+        return await query
+            .Skip((pageIndex.Value - 1) * pageSize.Value)
+            .Take(pageSize.Value)
+            .ToListAsync();
     }
 
     public async Task<T> GetByIdAsync(Guid id)

--- a/CadastroApi/UnitTest/AdicionarContatoTests.cs
+++ b/CadastroApi/UnitTest/AdicionarContatoTests.cs
@@ -5,7 +5,7 @@ using CadastroApi.Repository;
 using FluentAssertions;
 using FluentValidation;
 
-namespace AdicionarContato
+namespace UnitTest
 {
     public class AdicionarContatoTests
     {

--- a/CadastroApi/UnitTest/AtualizarContatoTests.cs
+++ b/CadastroApi/UnitTest/AtualizarContatoTests.cs
@@ -4,7 +4,7 @@ using CadastroApi.Repository;
 using FluentAssertions;
 using Moq;
 
-namespace AtualizarContato
+namespace UnitTest
 {
     public class AtualizarContatoTests
     {

--- a/CadastroApi/UnitTest/ListarContatoTests.cs
+++ b/CadastroApi/UnitTest/ListarContatoTests.cs
@@ -1,52 +1,70 @@
-﻿using Moq;
-using CadastroApi.Application;
+﻿using CadastroApi.Application;
+using CadastroApi.Controllers;
 using CadastroApi.Models;
 using CadastroApi.Repository;
-using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
 
 namespace UnitTest
 {
     public class ListarContatoTests
     {
+        private readonly Mock<IMediator> _mediatorMock;
         private readonly Mock<IContatoRepository> _contatoRepositoryMock;
-        private readonly ListarContatoQueryHandler _handler;
+        private readonly ContatosController _controller;
 
         public ListarContatoTests()
         {
             _contatoRepositoryMock = new Mock<IContatoRepository>();
-            _handler = new ListarContatoQueryHandler(_contatoRepositoryMock.Object);
+            _mediatorMock = new Mock<IMediator>();
+            _controller = new ContatosController(_contatoRepositoryMock.Object, _mediatorMock.Object);
         }
 
         [Fact]
-        public async Task ListarTodosContatos_DeveRetornarListaDeContatos()
+        public async Task ListarContatos_ParametrosNaoInformados_DeveRetornarTodosContatos()
         {
             var contatos = new List<Contato>
-        {
-            new Contato { Nome = "Felipe Dantas", Telefone = "999999999", DDD = "11", Email = "felipe@example.com" },
-            new Contato { Nome = "Maria Silva", Telefone = "888888888", DDD = "21", Email = "maria@example.com" }
-        };
-            _contatoRepositoryMock.Setup(repo => repo.GetAllAsync(It.IsAny<int?>(), It.IsAny<int?>())).ReturnsAsync(contatos);
+            {
+                new() { Nome = "Batman", Telefone = "999999999", DDD = "11", Email = "batman@gotham.com" },
+                new() { Nome = "Robin", Telefone = "888888888", DDD = "21", Email = "robin@gotham.com" }
+            };
 
-            var result = await _handler.Handle(new ListarContatoQuery(), CancellationToken.None);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ListarContatoQuery>(), It.IsAny<CancellationToken>()))
+                     .ReturnsAsync(contatos);
 
-            result.Should().BeEquivalentTo(contatos); 
-            _contatoRepositoryMock.Verify(repo => repo.GetAllAsync(null, null), Times.Once);
+            var result = await _controller.ListarContatos();
+
+            var okResultObject = Assert.IsType<OkObjectResult>(result);
+
+            Assert.Equal(contatos, okResultObject.Value);
+            
         }
 
-        [Fact]
-        public async Task ListarTodosContatos_DDDInformado_DeveRetornarListaDeContatos()
+        [Theory]
+        [InlineData("11", null, null)]        
+        [InlineData("11", 1, null)]
+        [InlineData("11", 1, 1)]
+        [InlineData(null, 1, null)]
+        [InlineData(null, 1, 1)]
+        [InlineData(null, null, 1)]
+        [InlineData(null, null, null)]
+        public async Task ListarContatos_ParametrosInformados_DeveRetornarListaFiltrada(string? ddd = null, int? pageIndex = null, int? pageSize = null)
         {
             var contatos = new List<Contato>
-        {
-            new Contato { Nome = "Batman", Telefone = "999999999", DDD = "11", Email = "batman@gotham.com" },
-            new Contato { Nome = "Robin", Telefone = "999999999", DDD = "11", Email = "robin@gotham.com" },
-        };
-            _contatoRepositoryMock.Setup(repo => repo.GetByDDDAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int?>())).ReturnsAsync(contatos);
+            {
+                new() { Nome = "Batman", Telefone = "999999999", DDD = "11", Email = "batman@gotham.com" },
+                new() { Nome = "Robin", Telefone = "888888888", DDD = "11", Email = "robin@gotham.com" }
+            };
 
-            var result = await _handler.Handle(new ListarContatoQuery { DDD = "11"}, CancellationToken.None);
+            _mediatorMock.Setup(m => m.Send(It.IsAny<ListarContatoQuery>(), It.IsAny<CancellationToken>()))
+                     .ReturnsAsync(contatos);
 
-            result.Should().BeEquivalentTo(contatos);
-            _contatoRepositoryMock.Verify(repo => repo.GetByDDDAsync("11", null, null), Times.Once);
+            var result = await _controller.ListarContatos(ddd, pageIndex, pageSize);
+
+            var okResultObject = Assert.IsType<OkObjectResult>(result);
+
+            Assert.Equal(contatos, okResultObject.Value);
         }
     }
 }

--- a/CadastroApi/UnitTest/ListarContatoTests.cs
+++ b/CadastroApi/UnitTest/ListarContatoTests.cs
@@ -4,7 +4,7 @@ using CadastroApi.Models;
 using CadastroApi.Repository;
 using FluentAssertions;
 
-namespace ListarContato
+namespace UnitTest
 {
     public class ListarContatoTests
     {
@@ -25,12 +25,12 @@ namespace ListarContato
             new Contato { Nome = "Felipe Dantas", Telefone = "999999999", DDD = "11", Email = "felipe@example.com" },
             new Contato { Nome = "Maria Silva", Telefone = "888888888", DDD = "21", Email = "maria@example.com" }
         };
-            _contatoRepositoryMock.Setup(repo => repo.GetAllAsync()).ReturnsAsync(contatos);
+            _contatoRepositoryMock.Setup(repo => repo.GetAllAsync(It.IsAny<int?>(), It.IsAny<int?>())).ReturnsAsync(contatos);
 
             var result = await _handler.Handle(new ListarContatoQuery(), CancellationToken.None);
 
             result.Should().BeEquivalentTo(contatos); 
-            _contatoRepositoryMock.Verify(repo => repo.GetAllAsync(), Times.Once);
+            _contatoRepositoryMock.Verify(repo => repo.GetAllAsync(null, null), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
- Alterado namespace das classes de teste.
- Ajustado unit tests de Listar e Atualizar contato para testar a classe controladora ao invés do handler, seguindo o padrão estabelecido em `RemoverContatoTests`.
- Adicionado documentação ao método `AdicionarContato`.
- Ajustado retornos do método `AdicionarContato`.
- Ajustado retornos do método `AtualizarContato`.
- Removido implementação em duplicidade em `ContatoRepository` .
- Ajustado o método `Repository.GetAllAsync` para que suporte paginação.
- Adicionado extensão para formatar erros do validador em resposta.

closes: #30 